### PR TITLE
feat(OpsgeniePage): support custom Opsgenie page

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,30 @@ annotations:
 ```
 
 This annotation accepts any valid [Opsgenie search query](https://support.atlassian.com/opsgenie/docs/search-queries-for-alerts/) for alerts.
+
+## Customizations
+
+The Opsgenie page can be customized.
+
+```tsx
+// CustomOpsGeniePage.tsx
+export const CustomOpsgeniePage = () => {
+  return (
+    <Layout>
+      <Layout.Route path="who-is-on-call" title="Who is on-call">
+        <OnCallList />
+      </Layout.Route>
+    </Layout>
+  );
+};
+```
+
+```tsx
+// App.tsx
+import { CustomOpsgeniePage } from './CustomOpsgeniePage';
+
+// ...
+<Route path="/opsgenie" element={<OpsgeniePage />} >
+  <CustomOpsgeniePage />
+</Route>
+```

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "moment": "^2.29.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4",
     "recharts": "^2.0.9",

--- a/src/components/OpsgeniePage/DefaultOpsgeniePage.tsx
+++ b/src/components/OpsgeniePage/DefaultOpsgeniePage.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { AlertsList } from '../AlertsTable';
+import { IncidentsList } from '../IncidentsTable';
+import { OnCallList } from '../OnCallList';
+import { Analytics } from '../Analytics';
+import { Layout } from './Layout';
+
+export const DefaultOpsgeniePage = () => {
+    return (
+        <Layout>
+            <Layout.Route path="who-is-on-call" title="Who is on-call">
+                <OnCallList />
+            </Layout.Route>
+            <Layout.Route path="alerts" title="Alerts">
+                <AlertsList />
+            </Layout.Route>
+            <Layout.Route path="incidents" title="Incidents">
+                <IncidentsList />
+            </Layout.Route>
+            <Layout.Route path="analytics" title="Analytics">
+                <Analytics />
+            </Layout.Route>
+        </Layout>
+    );
+};

--- a/src/components/OpsgeniePage/OpsgeniePage.tsx
+++ b/src/components/OpsgeniePage/OpsgeniePage.tsx
@@ -1,25 +1,9 @@
 import React from 'react';
-import { AlertsList } from '../AlertsTable';
-import { IncidentsList } from '../IncidentsTable';
-import { OnCallList } from '../OnCallList';
-import { Analytics } from '../Analytics';
-import { Layout } from './Layout';
+import { useOutlet } from 'react-router';
+import { DefaultOpsgeniePage } from './DefaultOpsgeniePage';
 
 export const OpsgeniePage = () => {
-    return (
-        <Layout>
-            <Layout.Route path="who-is-on-call" title="Who is on-call">
-                <OnCallList />
-            </Layout.Route>
-            <Layout.Route path="alerts" title="Alerts">
-                <AlertsList />
-            </Layout.Route>
-            <Layout.Route path="incidents" title="Incidents">
-                <IncidentsList />
-            </Layout.Route>
-            <Layout.Route path="analytics" title="Analytics">
-                <Analytics />
-            </Layout.Route>
-        </Layout>
-    );
+  const outlet = useOutlet();
+
+  return outlet || <DefaultOpsgeniePage />;
 };

--- a/src/components/OpsgeniePage/index.ts
+++ b/src/components/OpsgeniePage/index.ts
@@ -1,1 +1,2 @@
 export { OpsgeniePage } from './OpsgeniePage';
+export { Layout } from './Layout';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,8 @@ export * from './extensions';
 export { opsGeniePlugin } from './plugin';
 export * from './api';
 export * from './integration';
+export { Layout } from './components/OpsgeniePage';
+export { AlertsList } from './components/AlertsTable';
+export { IncidentsList } from './components/IncidentsTable';
+export { OnCallList } from './components/OnCallList';
+export { Analytics } from './components/Analytics';


### PR DESCRIPTION
This adds support for consumers to supply their own custom Opsgenie page layouts following the same customization mechanism in Backstage for search, catalog import, and techdocs pages.

See below example for how to supply a custom page:
```tsx
// CustomOpsGeniePage.tsx
export const CustomOpsgeniePage = () => {
  return (
    <Layout>
      <Layout.Route path="who-is-on-call" title="Who is on-call">
        <OnCallList />
      </Layout.Route>
    </Layout>
  );
};
```
```tsx
// App.tsx
import { CustomOpsgeniePage } from './CustomOpsgeniePage';

// ...
<Route path="/opsgenie" element={<OpsgeniePage />} >
  <CustomOpsgeniePage />
</Route>
```