### PR TITLE
Add query as parameter when fetching alarms

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -10,6 +10,7 @@ export const opsgenieApiRef = createApiRef<Opsgenie>({
 
 type AlertsFetchOpts = {
   limit?: number
+  query?: string
 }
 
 type IncidentsFetchOpts = {
@@ -20,7 +21,7 @@ type IncidentsFetchOpts = {
 }
 
 export interface Opsgenie {
-  getAlerts(opts?: AlertsFetchOpts): Promise<Alert[]>;
+  getAlerts(opts?: AlertsFetchOpts, query?: string): Promise<Alert[]>;
   getIncidents(opts?: IncidentsFetchOpts): Promise<Incident[]>;
 
   getAlertsForEntity(entity: Entity, opts?: AlertsFetchOpts): Promise<Alert[]>;
@@ -122,7 +123,8 @@ export class OpsgenieApi implements Opsgenie {
 
   async getAlerts(opts?: AlertsFetchOpts): Promise<Alert[]> {
     const limit = opts?.limit || 50;
-    const response = await this.fetch<AlertsResponse>(`/v2/alerts?limit=${limit}`);
+    const query = opts?.query ? `&query=${opts?.query}` : '';
+    const response = await this.fetch<AlertsResponse>(`/v2/alerts?limit=${limit}${query}`);
 
     return response.data;
   }


### PR DESCRIPTION
In addition to the plugin view we would like to use the api you created in our Backstage installation to create custom views of alerts based on their tags. 

Adding the query parameter to the `AlertsFetchOptions` allow us to retrieve a limited list of alerts that are not related to an entity (i.e. using the `getAlertsForEntity` method). I added the `query` field to the `AlertFetchOptions` as I saw that is a patter already used for `IncidentsFetchOpts`
