### PR TITLE
Expose cardsPerPage prop for OnCallList in OpsgeniePage

### DIFF
--- a/src/components/OpsgeniePage/DefaultOpsgeniePage.tsx
+++ b/src/components/OpsgeniePage/DefaultOpsgeniePage.tsx
@@ -4,12 +4,13 @@ import { IncidentsList } from '../IncidentsTable';
 import { OnCallList } from '../OnCallList';
 import { Analytics } from '../Analytics';
 import { Layout } from './Layout';
+import {OpsgeniePageProps} from "./OpsgeniePage";
 
-export const DefaultOpsgeniePage = () => {
+export const DefaultOpsgeniePage = ({ onCallListCardsCount }: OpsgeniePageProps) => {
     return (
         <Layout>
             <Layout.Route path="who-is-on-call" title="Who is on-call">
-                <OnCallList />
+                <OnCallList cardsPerPage={onCallListCardsCount}/>
             </Layout.Route>
             <Layout.Route path="alerts" title="Alerts">
                 <AlertsList />

--- a/src/components/OpsgeniePage/OpsgeniePage.tsx
+++ b/src/components/OpsgeniePage/OpsgeniePage.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import { useOutlet } from 'react-router';
 import { DefaultOpsgeniePage } from './DefaultOpsgeniePage';
 
-export const OpsgeniePage = () => {
+export type OpsgeniePageProps = {
+  onCallListCardsCount?: number;
+};
+
+export const OpsgeniePage = ({ onCallListCardsCount }: OpsgeniePageProps) => {
   const outlet = useOutlet();
 
-  return outlet || <DefaultOpsgeniePage />;
+  return outlet || <DefaultOpsgeniePage onCallListCardsCount={onCallListCardsCount}/>;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@backstage/cli/config/tsconfig.json",
   "include": ["src", "dev"],
   "compilerOptions": {
+    "jsx": "react",
     "outDir": "dist-types",
     "incremental": false
   }


### PR DESCRIPTION
This exposes the new cardsPerPage prop for the OnCallList component at the top Page level so that plugin users can easily set it. 