### PR TITLE
Make fetching on-call schedules resilient and  display schedule names

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -174,7 +174,7 @@ export class OpsgenieApi implements Opsgenie {
   async getSchedulesForTeam(name: string): Promise<Schedule[]> {
     const response = await this.fetch<SchedulesResponse>("/v2/schedules");
 
-    return response.data.filter(schedule => schedule.ownerTeam.name === name);
+    return response.data.filter(schedule => schedule.ownerTeam && schedule.ownerTeam.name === name);
   }
 
   async getTeams(): Promise<Team[]> {

--- a/src/components/OnCallList/OnCallList.tsx
+++ b/src/components/OnCallList/OnCallList.tsx
@@ -69,11 +69,11 @@ export const OnCallForScheduleList = ({ schedule }: { schedule: Schedule }) => {
                         <PersonIcon />
                     </ListItemIcon>
 
-                    <ListItemText primary={responder.name} />
+                    <ListItemText primary={responder.name - (schedule.name)} />
                 </ListItem>
             ))}
 
-            {value!.length === 0 && <ListItem><ListItemText primary="⚠️ No one on-call." /></ListItem>}
+            {value!.length === 0 && <ListItem><ListItemText primary={"⚠️ No one on-call for schedule '" + schedule.name + "'."} /></ListItem>}
         </List>
     );
 };


### PR DESCRIPTION
First of all, thank you for creating this great plugin! Really like the integration so far.

While testing this out with a live system I've noticed some small things that could be improved, hence this MR:
- When no `ownerTeam` is defined for a schedule you'll get a `name is undefined` error 
- When multiple schedules refer to an owerTeam it's really unclear why names show up multiple times (e.g. when multiple schedules are overlap). My suggestion there would be to add the schedule to the name to indicate this.

Happy to make adjustments when needed.