### PR TITLE
Add schedule annotation

### DIFF
--- a/docs/who-is-on-call-on-component-page.md
+++ b/docs/who-is-on-call-on-component-page.md
@@ -44,3 +44,12 @@ annotations:
 ```
 
 This annotation accepts any valid OpsGenie team name.
+
+If your OpsGenie teams do not directly own schedules (ie. shared schedule), specify the schedule name instead of a team
+name and add an annotation to specify that the team name is actually a schedule:
+
+```yml
+annotations:
+  opsgenie.com/team: 'Awesome Schedule'
+  opsgenie.com/isSchedule: 'true'
+```

--- a/src/api.ts
+++ b/src/api.ts
@@ -30,6 +30,7 @@ export interface Opsgenie {
 
   getSchedules(): Promise<Schedule[]>;
   getSchedulesForTeam(name: string): Promise<Schedule[]>;
+  getSchedulesByName(name: string): Promise<Schedule[]>;
   getOnCall(scheduleId: string): Promise<OnCallParticipantRef[]>;
 
   getTeams(): Promise<Team[]>;
@@ -175,6 +176,12 @@ export class OpsgenieApi implements Opsgenie {
     const response = await this.fetch<SchedulesResponse>("/v2/schedules");
 
     return response.data.filter(schedule => schedule.ownerTeam && schedule.ownerTeam.name === name);
+  }
+
+  async getSchedulesByName(name: string): Promise<Schedule[]> {
+    const response = await this.fetch<SchedulesResponse>("/v2/schedules");
+
+    return response.data.filter(schedule => schedule.name === name);
   }
 
   async getTeams(): Promise<Team[]> {

--- a/src/components/Entity/OnCallListCard.tsx
+++ b/src/components/Entity/OnCallListCard.tsx
@@ -49,7 +49,7 @@ const OnCallListCardContent = ({teamName, isSchedule}: OnCallListContentProps) =
 export const OnCallListCard = ({ title, variant }: OnCallListCardProps) => {
     const { entity } = useEntity();
     const teamName = entity.metadata.annotations?.[OPSGENIE_TEAM_ANNOTATION];
-    let isSchedule = entity.metadata.annotations?.[OPSGENIE_IS_SCHEDULE_ANNOTATION]?.toLowerCase() === 'true' || false;
+    const isSchedule = entity.metadata.annotations?.[OPSGENIE_IS_SCHEDULE_ANNOTATION]?.toLowerCase() === 'true' || false;
 
     if (!teamName) {
         return <MissingAnnotationEmptyState annotation={OPSGENIE_TEAM_ANNOTATION} />;

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -2,6 +2,7 @@ import { Entity } from "@backstage/catalog-model";
 
 export const OPSGENIE_ANNOTATION = 'opsgenie.com/component-selector';
 export const OPSGENIE_TEAM_ANNOTATION = 'opsgenie.com/team';
+export const OPSGENIE_IS_SCHEDULE_ANNOTATION = 'opsgenie.com/isSchedule';
 
 export const isOpsgenieAvailable = (entity: Entity) => Boolean(entity.metadata.annotations?.[OPSGENIE_ANNOTATION]);
 export const isOpsgenieOnCallListAvailable = (entity: Entity) => Boolean(entity.metadata.annotations?.[OPSGENIE_TEAM_ANNOTATION]);


### PR DESCRIPTION
Add a second annotation `isSchedule` to allow the annotation to be a schedule name instead of a team name. This is a bit cumbersome but maintains backwards compatibility