### PR TITLE
chore: Prevent who-is-oncall from erroring out when ownerTeam is empty

### DIFF
--- a/src/components/OnCallList/OnCallList.tsx
+++ b/src/components/OnCallList/OnCallList.tsx
@@ -97,7 +97,7 @@ export const OnCallForScheduleCard = ({ schedule, responderFormatter }: { schedu
       <Tooltip title={schedule.enabled ? 'Enabled' : 'Disabled'}>
         <div>{schedule.enabled ? <StatusOK /> : <StatusAborted />}</div>
       </Tooltip>
-      {schedule.ownerTeam.name}
+      {schedule.ownerTeam ? schedule.ownerTeam.name : ""}
     </div>
   );
 


### PR DESCRIPTION
Current Behavior: Who is on call tab errors out rendering when `ownerTeam` is empty. Issue reported [here](https://github.com/K-Phoen/backstage-plugin-opsgenie/issues/118)

Fix: With the `OnCallForScheduleCard` fix, Opsgenie plugin renders without any error.

<img width="1374" alt="Screen Shot 2023-10-20 at 1 42 49 PM" src="https://github.com/K-Phoen/backstage-plugin-opsgenie/assets/104038058/7f4933ba-66aa-4ade-912a-6d7d5d145cd5">

