### PR TITLE
Update team check to be case sensitive

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -189,7 +189,7 @@ export class OpsgenieApi implements Opsgenie {
   async getSchedulesForTeam(name: string): Promise<Schedule[]> {
     const response = await this.fetch<SchedulesResponse>("/v2/schedules");
 
-    return response.data.filter(schedule => schedule.ownerTeam && schedule.ownerTeam.name === name);
+    return response.data.filter(schedule => schedule.ownerTeam && schedule.ownerTeam.name.toLowerCase() === name.toLowerCase());
   }
 
   async getTeams(): Promise<Team[]> {


### PR DESCRIPTION
We enrich entities with the necessary annotations via the catalog processor. It's very hard to guess the exact casing of the team in Opsgenie which this requires.

The change updates the check to be case sensitive. 